### PR TITLE
Update rand_core to 0.6 for 4.0.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Entries are listed in reverse chronological order per major series.
 
+## 4.x series
+
+### 4.0.0
+
+* Update the `rand_core` dependency to `0.6`.  This requires a major version
+  because the `digest` traits are part of the public API, but there are
+  otherwise no changes to the API.
+
 ## 3.x series
 
 ### 3.0.3
@@ -23,7 +31,7 @@ Entries are listed in reverse chronological order per major series.
   because the `digest` traits are part of the public API, but there are
   otherwise no changes to the API.
 
-## 2.x series
+## 2.x series (unsupported)
 
 ### 2.1.2
 
@@ -57,7 +65,7 @@ Entries are listed in reverse chronological order per major series.
 The only significant change is the data model change to the `serde` feature;
 besides the `rand_core` version bump, there are no other user-visible changes.
 
-## 1.x series
+## 1.x series (unsupported)
 
 ### 1.2.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "curve25519-dalek-ng"
 # - update CHANGELOG
 # - update html_root_url
 # - update README if required by semver
-version = "3.0.3"
+version = "4.0.0"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"
@@ -29,14 +29,14 @@ features = ["nightly", "simd_backend"]
 sha2 = { version = "0.9", default-features = false }
 bincode = "1"
 criterion = "0.3.0"
-rand = "0.7"
+rand = "0.8"
 
 [[bench]]
 name = "dalek_benchmarks"
 harness = false
 
 [dependencies]
-rand_core = { version = "0.5", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.9", default-features = false }
 subtle = { package = "subtle-ng", version = "^2.2.1", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 #![cfg_attr(feature = "nightly", deny(missing_docs))]
 
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
-#![doc(html_root_url = "https://docs.rs/curve25519-dalek-ng/3.0.3")]
+#![doc(html_root_url = "https://docs.rs/curve25519-dalek-ng/4.0.0")]
 
 //! Note that docs will only build on nightly Rust until
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).


### PR DESCRIPTION
`curve25519-dalek` exports the `rand_core` API as part of its API, so
changes to the `rand_core` (or `digest`) version require version bumps.
In the past, this has been an automatic major version bump as soon as
there was a new release, to prevent getting out of sync with the rest of
the ecosystem, and that should probably continue to create
`curve25519-dalek-ng` `4.0.0`.

Closes #2