### PR TITLE
Add TryFrom<[u8; 32]> implementations for Scalar and EdwardsPoint

### DIFF
--- a/src/backend/serial/curve_models/mod.rs
+++ b/src/backend/serial/curve_models/mod.rs
@@ -122,7 +122,7 @@
 
 #![allow(non_snake_case)]
 
-use core::fmt::Debug;
+use core::fmt;
 use core::ops::{Add, Neg, Sub};
 
 use subtle::Choice;
@@ -519,29 +519,29 @@ impl<'a> Neg for &'a AffineNielsPoint {
 // Debug traits
 // ------------------------------------------------------------------------
 
-impl Debug for ProjectivePoint {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for ProjectivePoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ProjectivePoint{{\n\tX: {:?},\n\tY: {:?},\n\tZ: {:?}\n}}",
                &self.X, &self.Y, &self.Z)
     }
 }
 
-impl Debug for CompletedPoint {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for CompletedPoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "CompletedPoint{{\n\tX: {:?},\n\tY: {:?},\n\tZ: {:?},\n\tT: {:?}\n}}",
                &self.X, &self.Y, &self.Z, &self.T)
     }
 }
 
-impl Debug for AffineNielsPoint {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for AffineNielsPoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "AffineNielsPoint{{\n\ty_plus_x: {:?},\n\ty_minus_x: {:?},\n\txy2d: {:?}\n}}",
                &self.y_plus_x, &self.y_minus_x, &self.xy2d)
     }
 }
 
-impl Debug for ProjectiveNielsPoint {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for ProjectiveNielsPoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ProjectiveNielsPoint{{\n\tY_plus_X: {:?},\n\tY_minus_X: {:?},\n\tZ: {:?},\n\tT2d: {:?}\n}}",
                &self.Y_plus_X, &self.Y_minus_X, &self.Z, &self.T2d)
     }

--- a/src/backend/serial/u32/field.rs
+++ b/src/backend/serial/u32/field.rs
@@ -15,7 +15,7 @@
 //! implementation, and was then rewritten to use unsigned limbs instead
 //! of signed limbs.
 
-use core::fmt::Debug;
+use core::fmt;
 use core::ops::Neg;
 use core::ops::{Add, AddAssign};
 use core::ops::{Mul, MulAssign};
@@ -51,8 +51,8 @@ use zeroize::Zeroize;
 #[derive(Copy, Clone)]
 pub struct FieldElement2625(pub (crate) [u32; 10]);
 
-impl Debug for FieldElement2625 {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for FieldElement2625 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "FieldElement2625({:?})", &self.0[..])
     }
 }

--- a/src/backend/serial/u32/scalar.rs
+++ b/src/backend/serial/u32/scalar.rs
@@ -10,7 +10,7 @@
 //! -0x1ffffffe00000008 (62 bits with sign bit) to
 //! 0x43fffffbc0000011 (63 bits), which is still safe.
 
-use core::fmt::Debug;
+use core::fmt;
 use core::ops::{Index, IndexMut};
 
 use zeroize::Zeroize;
@@ -21,8 +21,8 @@ use constants;
 #[derive(Copy,Clone)]
 pub struct Scalar29(pub [u32; 9]);
 
-impl Debug for Scalar29 {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for Scalar29 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Scalar29: {:?}", &self.0[..])
     }
 }

--- a/src/backend/serial/u64/field.rs
+++ b/src/backend/serial/u64/field.rs
@@ -11,7 +11,7 @@
 //! Field arithmetic modulo \\(p = 2\^{255} - 19\\), using \\(64\\)-bit
 //! limbs with \\(128\\)-bit products.
 
-use core::fmt::Debug;
+use core::fmt;
 use core::ops::Neg;
 use core::ops::{Add, AddAssign};
 use core::ops::{Mul, MulAssign};
@@ -40,8 +40,8 @@ use zeroize::Zeroize;
 #[derive(Copy, Clone)]
 pub struct FieldElement51(pub (crate) [u64; 5]);
 
-impl Debug for FieldElement51 {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for FieldElement51 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "FieldElement51({:?})", &self.0[..])
     }
 }

--- a/src/backend/serial/u64/scalar.rs
+++ b/src/backend/serial/u64/scalar.rs
@@ -11,7 +11,7 @@
 //! (0xfffffffffffff^2) * 5 = 0x4ffffffffffff60000000000005 (107 bits).
 //! ```
 
-use core::fmt::Debug;
+use core::fmt;
 use core::ops::{Index, IndexMut};
 
 use zeroize::Zeroize;
@@ -23,8 +23,8 @@ use constants;
 #[derive(Copy,Clone)]
 pub struct Scalar52(pub [u64; 5]);
 
-impl Debug for Scalar52 {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for Scalar52 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Scalar52: {:?}", &self.0[..])
     }
 }

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -99,6 +99,7 @@ use core::iter::Sum;
 use core::ops::{Add, Neg, Sub};
 use core::ops::{AddAssign, SubAssign};
 use core::ops::{Mul, MulAssign};
+use core::convert::TryFrom;
 
 use subtle::Choice;
 use subtle::ConditionallyNegatable;
@@ -366,6 +367,27 @@ impl Default for EdwardsPoint {
         EdwardsPoint::identity()
     }
 }
+
+impl TryFrom<[u8; 32]> for EdwardsPoint {
+    type Error = InvalidYCoordinate;
+
+    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
+        CompressedEdwardsY(bytes).decompress().ok_or(InvalidYCoordinate)
+    }
+}
+
+/// Error type in case the provided bytes don't represent a valid Y coordinate of a curve point.
+#[derive(Debug)]
+pub struct InvalidYCoordinate;
+
+impl fmt::Display for InvalidYCoordinate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "given bytes are not a valid Y coordinate of a curve point")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidYCoordinate { }
 
 // ------------------------------------------------------------------------
 // Validity checks (for debugging, not CT)

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -93,7 +93,7 @@
 #![allow(non_snake_case)]
 
 use core::borrow::Borrow;
-use core::fmt::Debug;
+use core::fmt;
 use core::iter::Iterator;
 use core::iter::Sum;
 use core::ops::{Add, Neg, Sub};
@@ -159,8 +159,8 @@ impl ConstantTimeEq for CompressedEdwardsY {
     }
 }
 
-impl Debug for CompressedEdwardsY {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for CompressedEdwardsY {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "CompressedEdwardsY: {:?}", self.as_bytes())
     }
 }
@@ -250,7 +250,7 @@ impl<'de> Deserialize<'de> for EdwardsPoint {
         impl<'de> Visitor<'de> for EdwardsPointVisitor {
             type Value = EdwardsPoint;
 
-            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a valid point in Edwards y + sign format")
             }
 
@@ -282,7 +282,7 @@ impl<'de> Deserialize<'de> for CompressedEdwardsY {
         impl<'de> Visitor<'de> for CompressedEdwardsYVisitor {
             type Value = CompressedEdwardsY;
 
-            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("32 bytes of data")
             }
 
@@ -923,8 +923,8 @@ impl EdwardsPoint {
 // Debug traits
 // ------------------------------------------------------------------------
 
-impl Debug for EdwardsPoint {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for EdwardsPoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "EdwardsPoint{{\n\tX: {:?},\n\tY: {:?},\n\tZ: {:?},\n\tT: {:?}\n}}",
                &self.X, &self.Y, &self.Z, &self.T)
     }

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -158,7 +158,7 @@
 //! https://ristretto.group/
 
 use core::borrow::Borrow;
-use core::fmt::Debug;
+use core::fmt;
 use core::iter::Sum;
 use core::ops::{Add, Neg, Sub};
 use core::ops::{AddAssign, SubAssign};
@@ -367,7 +367,7 @@ impl<'de> Deserialize<'de> for RistrettoPoint {
         impl<'de> Visitor<'de> for RistrettoPointVisitor {
             type Value = RistrettoPoint;
 
-            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a valid point in Ristretto format")
             }
 
@@ -399,7 +399,7 @@ impl<'de> Deserialize<'de> for CompressedRistretto {
         impl<'de> Visitor<'de> for CompressedRistrettoVisitor {
             type Value = CompressedRistretto;
 
-            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("32 bytes of data")
             }
 
@@ -1064,14 +1064,14 @@ impl ConditionallySelectable for RistrettoPoint {
 // Debug traits
 // ------------------------------------------------------------------------
 
-impl Debug for CompressedRistretto {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for CompressedRistretto {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "CompressedRistretto: {:?}", self.as_bytes())
     }
 }
 
-impl Debug for RistrettoPoint {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for RistrettoPoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let coset = self.coset4();
         write!(f, "RistrettoPoint: coset \n{:?}\n{:?}\n{:?}\n{:?}",
                coset[0], coset[1], coset[2], coset[3])

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -140,7 +140,7 @@
 
 use core::borrow::Borrow;
 use core::cmp::{Eq, PartialEq};
-use core::fmt::Debug;
+use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::Index;
 use core::ops::Neg;
@@ -252,8 +252,8 @@ impl Scalar {
     }
 }
 
-impl Debug for Scalar {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl fmt::Debug for Scalar {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Scalar{{\n\tbytes: {:?},\n}}", &self.bytes)
     }
 }
@@ -406,7 +406,7 @@ impl<'de> Deserialize<'de> for Scalar {
         impl<'de> Visitor<'de> for ScalarVisitor {
             type Value = Scalar;
 
-            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a valid point in Edwards y + sign format")
             }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -147,6 +147,7 @@ use core::ops::Neg;
 use core::ops::{Add, AddAssign};
 use core::ops::{Mul, MulAssign};
 use core::ops::{Sub, SubAssign};
+use core::convert::TryFrom;
 
 #[allow(unused_imports)]
 use prelude::*;
@@ -251,6 +252,27 @@ impl Scalar {
         s
     }
 }
+
+impl TryFrom<[u8; 32]> for Scalar {
+    type Error = NonCanonicalScalar;
+
+    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
+        Self::from_canonical_bytes(bytes).ok_or(NonCanonicalScalar)
+    }
+}
+
+/// Error type in case the provided bytes don't represent a canonical scalar.
+#[derive(Debug)]
+pub struct NonCanonicalScalar;
+
+impl fmt::Display for NonCanonicalScalar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "given bytes don't represent a canonical scalar")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for NonCanonicalScalar { }
 
 impl fmt::Debug for Scalar {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/window.rs
+++ b/src/window.rs
@@ -12,7 +12,7 @@
 
 #![allow(non_snake_case)]
 
-use core::fmt::Debug;
+use core::fmt;
 
 use subtle::ConditionallyNegatable;
 use subtle::ConditionallySelectable;
@@ -78,8 +78,8 @@ impl<T: Copy + Default> Default for LookupTable<T> {
     }
 }
 
-impl<T: Debug> Debug for LookupTable<T> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for LookupTable<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "LookupTable({:?})", self.0)
     }
 }
@@ -128,8 +128,8 @@ impl<T: Copy> NafLookupTable5<T> {
     }
 }
 
-impl<T: Debug> Debug for NafLookupTable5<T> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for NafLookupTable5<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "NafLookupTable5({:?})", self.0)
     }
 }
@@ -171,8 +171,8 @@ impl<T: Copy> NafLookupTable8<T> {
     }
 }
 
-impl<T: Debug> Debug for NafLookupTable8<T> {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for NafLookupTable8<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "NafLookupTable8([\n")?;
         for i in 0..64 {
             write!(f, "\t{:?},\n", &self.0[i])?;


### PR DESCRIPTION
First patch is a minor cleanup.
Second patch adds the functionality claimed in the title.