### PR TITLE
Update digest crate to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 features = ["nightly", "simd_backend"]
 
 [dev-dependencies]
-sha2 = { version = "0.9", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 bincode = "1"
 criterion = "0.3.0"
 rand = "0.8"
@@ -38,7 +38,7 @@ harness = false
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
-digest = { version = "0.9", default-features = false }
+digest = { version = "0.10", default-features = false }
 subtle = { package = "subtle-ng", version = "2.5", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 # The original packed_simd package was orphaned, see

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -573,7 +573,7 @@ impl Scalar {
     /// ```
     /// # extern crate curve25519_dalek_ng;
     /// # use curve25519_dalek_ng::scalar::Scalar;
-    /// extern crate sha2;
+    /// # extern crate sha2;
     ///
     /// use sha2::Sha512;
     ///
@@ -603,9 +603,10 @@ impl Scalar {
     /// ```
     /// # extern crate curve25519_dalek_ng;
     /// # use curve25519_dalek_ng::scalar::Scalar;
-    /// extern crate sha2;
+    /// # extern crate digest;
+    /// # extern crate sha2;
     ///
-    /// use sha2::Digest;
+    /// use digest::{Digest, Update};
     /// use sha2::Sha512;
     ///
     /// # fn main() {


### PR DESCRIPTION
This bumps the version number and fixes the tests.  That's all.  I'm not
qualified to answer the version number question.

Fixes #16.