### PR TITLE
Switch back to packed_simd dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,7 @@ byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] 
 digest = { version = "0.9", default-features = false }
 subtle = { package = "subtle-ng", version = "2.5", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
-# The original packed_simd package was orphaned, see
-# https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
-packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
+packed_simd = { version = "0.3.9", features = ["into_bits"], optional = true }
 zeroize = { version = "1", default-features = false }
 
 [features]


### PR DESCRIPTION
packed_simd is now again being published under its original name.